### PR TITLE
Manejo de Errores, CRUD y Nueva Entidad (Categorías)

### DIFF
--- a/lib/api/services/categoria_service.dart
+++ b/lib/api/services/categoria_service.dart
@@ -1,0 +1,63 @@
+import 'package:dcristaldo/data/categoria_repository.dart';
+import 'package:dcristaldo/domain/categoria.dart';
+import 'package:dcristaldo/exceptions/api_exception.dart';
+class CategoriaService {
+  final CategoriaRepository _categoriaRepository= CategoriaRepository();
+  
+  // Obtener todas las categorías
+  Future<List<Categoria>> obtenerCategorias() async {
+    try {
+      return await _categoriaRepository.obtenerCategorias();
+    } catch (e) {
+      if (e is ApiException) {
+        // Propaga el mensaje contextual de ApiException
+        rethrow;
+      } else {
+        throw Exception('Error desconocido: $e');
+      }
+    }
+  }
+
+  // Crear una nueva categoría
+  Future<void> crearCategoria(Categoria categoria) async {
+    try {
+      await _categoriaRepository.crearCategoria(categoria);
+    } catch (e) {
+      if (e is ApiException) {
+        // Propaga el mensaje contextual de ApiException
+        throw Exception('Error en el servicio de categorías: ${e.message}');
+      } else {
+        throw Exception('Error desconocido: $e');
+      }
+    }
+  }
+
+  // Actualizar una categoría existente
+  Future<void> actualizarCategoria(String id, Categoria categoria) async {
+    try {
+      await _categoriaRepository.actualizarCategoria(id, categoria);
+    } catch (e) {
+      if (e is ApiException) {
+        // Propaga el mensaje contextual de ApiException
+        throw Exception('Error en el servicio de categorías: ${e.message}');
+      } else {
+        throw Exception('Error desconocido: $e');
+      }
+    }
+  }
+
+
+  // Eliminar una categoría
+  Future<void> eliminarCategoria(String id) async {
+    try {
+      await _categoriaRepository.eliminarCategoria(id);
+    } catch (e) {
+      if (e is ApiException) {
+        // Propaga el mensaje contextual de ApiException
+        rethrow;
+      } else {
+        throw Exception('Error desconocido: $e');
+      }
+    }
+  }
+}

--- a/lib/api/services/categoria_service.dart
+++ b/lib/api/services/categoria_service.dart
@@ -1,63 +1,83 @@
-import 'package:dcristaldo/data/categoria_repository.dart';
 import 'package:dcristaldo/domain/categoria.dart';
+import 'package:dio/dio.dart';
+import 'package:dcristaldo/constants.dart';
 import 'package:dcristaldo/exceptions/api_exception.dart';
+
 class CategoriaService {
-  final CategoriaRepository _categoriaRepository= CategoriaRepository();
-  
+  final Dio _dio = Dio();
+  final String path=CategoryConstants.categoriaEndpoint;
   // Obtener todas las categorías
-  Future<List<Categoria>> obtenerCategorias() async {
+   Future<List<Categoria>> obtenerCategorias() async {
     try {
-      return await _categoriaRepository.obtenerCategorias();
-    } catch (e) {
-      if (e is ApiException) {
-        // Propaga el mensaje contextual de ApiException
-        rethrow;
+      final response = await _dio.get(path);
+
+      if (response.statusCode == 200) {
+        final List<dynamic> categoriasJson = response.data;
+        return categoriasJson.map((json) => Categoria.fromJson(json)).toList();
       } else {
-        throw Exception('Error desconocido: $e');
+        throw ApiException(
+          'Error al obtener las categorías',
+          statusCode: response.statusCode,
+        );
       }
+    } on DioException catch (e) {
+      throw ApiException(
+        'Error al conectar con la API de categorías: $e',
+        statusCode: e.response?.statusCode,
+      );
+    } catch (e) {
+      throw ApiException('Error desconocido: $e');
     }
   }
 
   // Crear una nueva categoría
   Future<void> crearCategoria(Categoria categoria) async {
     try {
-      await _categoriaRepository.crearCategoria(categoria);
-    } catch (e) {
-      if (e is ApiException) {
-        // Propaga el mensaje contextual de ApiException
-        throw Exception('Error en el servicio de categorías: ${e.message}');
-      } else {
-        throw Exception('Error desconocido: $e');
+      final response = await _dio.post(
+        path,
+        data: categoria.toJson(),
+      );
+      if (response.statusCode != 201) {
+        throw ApiException(
+          'Error al crear la categoría',
+          statusCode: response.statusCode,
+        );
       }
+    } catch (e) {
+      throw ApiException('Error al conectar con la API de categorías: $e');
     }
   }
 
   // Actualizar una categoría existente
   Future<void> actualizarCategoria(String id, Categoria categoria) async {
     try {
-      await _categoriaRepository.actualizarCategoria(id, categoria);
-    } catch (e) {
-      if (e is ApiException) {
-        // Propaga el mensaje contextual de ApiException
-        throw Exception('Error en el servicio de categorías: ${e.message}');
-      } else {
-        throw Exception('Error desconocido: $e');
+      final response = await _dio.put(
+        '$path/$id',
+        data: categoria.toJson(),
+      );
+      if (response.statusCode != 200) {
+        throw ApiException(
+          'Error al editar la categoría',
+          statusCode: response.statusCode,
+        );
       }
+    } catch (e) {
+      throw ApiException('Error al conectar con la API de categorías: $e');
     }
   }
-
 
   // Eliminar una categoría
   Future<void> eliminarCategoria(String id) async {
     try {
-      await _categoriaRepository.eliminarCategoria(id);
-    } catch (e) {
-      if (e is ApiException) {
-        // Propaga el mensaje contextual de ApiException
-        rethrow;
-      } else {
-        throw Exception('Error desconocido: $e');
+      final response = await _dio.delete('$path/$id');
+      if (response.statusCode != 200 && response.statusCode != 204) {
+        throw ApiException(
+          'Error al eliminar la categoría',
+          statusCode: response.statusCode,
+        );
       }
+    } catch (e) {
+      throw ApiException('Error al conectar con la API de categorías: $e');
     }
   }
 }

--- a/lib/api/services/noticia_service.dart
+++ b/lib/api/services/noticia_service.dart
@@ -1,90 +1,141 @@
-import 'package:dcristaldo/data/noticia_repository.dart';
+import 'dart:async';
 import 'package:dcristaldo/domain/noticia.dart';
+import 'package:dio/dio.dart';
+import 'package:dcristaldo/constants.dart';
 
 class NoticiaService {
-  final NoticiaRepository _repository = NoticiaRepository();
-
-  /// Obtener todas las noticias sin paginación
-  Future<List<Noticia>> obtenerNoticias() async {
-    // Obtener todas las noticias desde el repositorio
-    final noticias = await _repository.obtenerNoticias();
-
-    // Validar que las noticias tengan datos válidos
-    for (final noticia in noticias) {
-      validarNoticia(noticia);
-    }
-
-    return noticias;
-  }
-
+  final Dio _dio = Dio(
+          BaseOptions(
+            connectTimeout: const Duration(seconds: CategoryConstants.timeoutSeconds),
+            receiveTimeout:const  Duration(seconds: CategoryConstants.timeoutSeconds),
+          ),
+        );
+  final String path=NewsConstants.noticiasEndpoint;
   /// Crear una nueva noticia
   Future<Noticia> crearNoticia(Noticia noticia) async {
-    try{
-      // Validar que los datos de la noticia sean válidos
-      validarNoticia(noticia);
-      // Enviar la noticia al repositorio
-      return await _repository.crearNoticia(noticia);
-    }catch(e){
+    try {
+      final response = await _dio.post(
+        path,
+        data: {
+          'titulo': noticia.titulo,
+          'descripcion': noticia.descripcion,
+          'fuente': noticia.fuente,
+          'publicadaEl': noticia.publicadaEl.toIso8601String(),
+          'urlImage': noticia.imagenUrl,
+          'categoriaId': noticia.categoriaId,
+        },
+      );
+      if (response.statusCode != 201) {
+        throw Exception('Error al crear la noticia: ${response.statusMessage}');
+      }else{
+        return Noticia.fromJson(response.data);
+      }
+    } catch (e) {
       throw Exception('Error al crear la noticia: $e');
     }
-    
+  }
+
+  /// Leer todas las noticias
+  Future<List<Noticia>> obtenerNoticias() async {
+    try {
+      final response = await _dio.get(path);
+
+      if (response.statusCode == 200) {
+        final List<dynamic> data = response.data ?? [];
+        return data.map((json) => Noticia.fromJson(json)).toList();
+      } else {
+        throw Exception('Error al obtener las noticias: ${response.statusMessage}');
+      }
+    } catch (e) {
+      throw Exception('Error al obtener las noticias: $e');
+    }
+  }
+
+  /// Leer una noticia por ID
+  Future<Noticia> obtenerNoticiaPorId(String id) async {
+    try {
+      final response = await _dio.get('$path/$id');
+
+      if (response.statusCode == 200) {
+        return Noticia.fromJson(response.data);
+      } else {
+        throw Exception('Error al obtener la noticia: ${response.statusMessage}');
+      }
+    } catch (e) {
+      throw Exception('Error al obtener la noticia: $e');
+    }
   }
 
   /// Actualizar una noticia
   Future<void> actualizarNoticia(String id, Noticia noticia) async {
-    validarNoticia(noticia);
-    await _repository.actualizarNoticia(id, noticia);
+    try {
+      final response = await _dio.put(
+        '$path/$id',
+        data: {
+          'titulo': noticia.titulo,
+          'descripcion': noticia.descripcion,
+          'fuente': noticia.fuente,
+          'publicadaEl': noticia.publicadaEl.toIso8601String(),
+          'urlImage': noticia.imagenUrl,
+          'categoriaId': noticia.categoriaId,
+        },
+      );
+
+      if (response.statusCode != 200) {
+        throw Exception('Error al actualizar la noticia: ${response.statusMessage}');
+      }
+    } catch (e) {
+      throw Exception('Error al actualizar la noticia: $e');
+    }
   }
 
   /// Eliminar una noticia
   Future<void> eliminarNoticia(String id) async {
-    // Eliminar la noticia desde el repositorio
-    await _repository.eliminarNoticia(id);
-  }
+    try {
+      final response = await _dio.delete('$path/$id');
 
-  /// Validar los datos de una noticia
-  void validarNoticia(Noticia noticia) {
-    if (noticia.publicadaEl.isAfter(DateTime.now())) {
-      throw ArgumentError('La fecha de publicación no puede estar en el futuro.');
-    }
-    if (noticia.titulo.trim().isEmpty) {
-      throw ArgumentError('El título de la noticia no puede estar vacío.');
-    }
-    if (noticia.descripcion.trim().isEmpty) {
-      throw ArgumentError('La descripción de la noticia no puede estar vacía.');
-    }
-    if (noticia.fuente.trim().isEmpty) {
-      throw ArgumentError('La fuente de la noticia no puede estar vacía.');
-    }
-    if (noticia.imagenUrl.trim().isEmpty) {
-      throw ArgumentError('La URL de la imagen no puede estar vacía.');
+      if (response.statusCode != 200 && response.statusCode != 204) {
+        throw Exception('Error al eliminar la noticia: ${response.statusMessage}');
+      }
+    } catch (e) {
+      throw Exception('Error al eliminar la noticia: $e');
     }
   }
-
-  /// Obtener noticias paginadas
-  /*Future<List<Noticia>> obtenerNoticiasPaginadas({
+  
+  /*Future<List<Noticia>> obtenerNoticiasDesdeApi({
     required int numeroPagina,
-    required int tamanoPaginaConst,
+    required int tamanoPagina,
   }) async {
-    // Validar que numeroPagina sea mayor o igual a 1 y tamañoPagina mayor a 0
-    if (numeroPagina < 1) {
-      throw ArgumentError('El número de página debe ser mayor o igual a 1.');
-    }
-    if (tamanoPaginaConst <= 0) {
-      throw ArgumentError('El tamaño de página debe ser mayor a 0.');
-    }
+    try {
+      // Realizar la solicitud HTTP a la API
+      final response = await _dio.get(
+        NewsConstants.url,
+      );
 
-    // Obtener las noticias paginadas desde el repositorio
-    final noticias = await _repository.obtenerNoticias(
-      numeroPagina: numeroPagina,
-      tamanoPagina: tamanoPaginaConst,
-    );
-
-    // Validar que las noticias tengan datos válidos
-    for (final noticia in noticias) {
-      validarNoticia(noticia);
+      if (response.statusCode == 200) {
+        final List<dynamic> data = response.data ?? [];
+        return data.map((json) => Noticia.fromJson(json)).toList();
+      } else {
+        throw Exception('Error al obtener las noticias: ${response.statusCode}');
+      }
+    } catch (e) {
+      throw Exception('Error al realizar la solicitud: $e');
     }
-
-    return noticias;
+  }
+  Future<void> crearNoticia(Noticia noticia) async {
+    try {
+      await _dio.post(
+        NewsConstants.url, // Cambia esta URL por la de tu API
+        data: {
+          'titulo': noticia.titulo,
+          'descripcion': noticia.descripcion,
+          'fuente': noticia.fuente,
+          'publicadaEl': noticia.publicadaEl.toIso8601String(),
+          'urlImage': noticia.imagenUrl,
+        },
+      );
+    } catch (e) {
+      throw Exception('Error al crear la noticia: $e');
+    }
   }*/
 }

--- a/lib/components/custom_form_modal.dart
+++ b/lib/components/custom_form_modal.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+
+class CustomFormModal extends StatelessWidget {
+  final String title;
+  final Map<String, TextEditingController> controllers;
+  final Map<String, String> fieldLabels;
+  final VoidCallback onSubmit;
+  final String submitButtonText;
+
+  const CustomFormModal({
+    super.key,
+    required this.title,
+    required this.controllers,
+    required this.fieldLabels,
+    required this.onSubmit,
+    this.submitButtonText = 'Guardar',
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(
+        top: 16.0,
+        left: 16.0,
+        right: 16.0,
+        bottom: MediaQuery.of(context).viewInsets.bottom + 16.0,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            title,
+            style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 16.0),
+          ...fieldLabels.entries.map((entry) {
+            final fieldName = entry.key;
+            final fieldLabel = entry.value;
+            return Padding(
+              padding: const EdgeInsets.only(bottom: 16.0),
+              child: TextFormField(
+                controller: controllers[fieldName],
+                decoration: InputDecoration(
+                  labelText: fieldLabel,
+                  border: const OutlineInputBorder(),
+                ),
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'El campo $fieldLabel es obligatorio';
+                  }
+                  return null;
+                },
+              ),
+            );
+          }),
+          ElevatedButton(
+            onPressed: onSubmit,
+            child: Text(submitButtonText),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/components/noticia_card.dart
+++ b/lib/components/noticia_card.dart
@@ -10,11 +10,11 @@ class NoticiaCard extends StatelessWidget {
   final VoidCallback? onDelete;
 
   const NoticiaCard({
-    Key? key,
+    super.key,
     required this.noticia,
     this.onEdit,
     this.onDelete,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/components/noticia_card.dart
+++ b/lib/components/noticia_card.dart
@@ -81,6 +81,13 @@ class NoticiaCard extends StatelessWidget {
                           color: Colors.grey,
                         ),
                       ),
+                      Text (
+                        'categoriaId: ${noticia.categoriaId}',
+                        style: const TextStyle(
+                          fontSize: 12,
+                          color: Colors.grey,
+                        ),
+                      ),
                     ],
                   ),
                 ),

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -58,6 +58,16 @@ class NewsConstants extends Constants {
   static const String mensajeCargando = 'Cargando noticias...';
   static const String listaVacia = 'No hay noticias disponibles';
   static const String mensajeError = 'Error al cargar las noticias';
-  static String get url => dotenv.env['API_URL'] ?? 'https://default.url';
+  static String get url => dotenv.env['base_url'] ?? 'https://default.url';
+  static String get noticiasEndpoint => '$url/noticias';
+
+}
+class CategoryConstants extends Constants{
+  static String get url => dotenv.env['base_url'] ?? 'https://default.url';
+  static String get categoriaEndpoint => '$url/categorias';
+  static const String timeoutSeconds = '10';
+  static const String errorTimeout = 'Tiempo de espera agotado';
+  static const String errorNocategoria= 'Categoría no encontrada';
+  static const String defaultcategoriaId= 'Sin categoria';
 }
 

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -18,8 +18,17 @@ class Constants {
   
   // Paginación
   static const int defaultPageSize = 10;
-}
 
+}
+class ErrorConstants {
+  static const String errorUnauthorized = 'No autorizado';
+  static const String errorNotFound = 'No encontrado';
+  static const String errorForbidden = 'Prohibido';
+  static const String errorServer = 'Error del servidor';
+  static const String timeout = 'Tiempo de espera agotado';
+  static const String errorMessage = 'Error al cargar los datos';
+  static const String errorUknown = 'Ocurrió un error desconocido';
+}
 class TaskConstants extends Constants {
   static const String appBarTitle = 'Mis Tareas';
   static const String taskTypeLabel = 'Tipo: ';
@@ -51,23 +60,27 @@ class FinanceConstants extends Constants {
   static const String emptyList = 'No hay cotizaciones disponibles';
 }
 
-
-
 class NewsConstants extends Constants {
   static const String tituloAppNoticias = 'Noticias técnicas';
   static const String mensajeCargando = 'Cargando noticias...';
   static const String listaVacia = 'No hay noticias disponibles';
   static const String mensajeError = 'Error al cargar las noticias';
+  static const String defaultcategoriaId= 'Sin categoria';
+  
   static String get url => dotenv.env['base_url'] ?? 'https://default.url';
   static String get noticiasEndpoint => '$url/noticias';
+
+  static const String errorUnauthorized= "No autorizado";
+  static const String errorNotFound= "Noticias no encontradas";
+  static const String errorServer= "Error del servidor";
 
 }
 class CategoryConstants extends Constants{
   static String get url => dotenv.env['base_url'] ?? 'https://default.url';
   static String get categoriaEndpoint => '$url/categorias';
-  static const String timeoutSeconds = '10';
+  static const int timeoutSeconds = 10;
   static const String errorTimeout = 'Tiempo de espera agotado';
   static const String errorNocategoria= 'Categoría no encontrada';
-  static const String defaultcategoriaId= 'Sin categoria';
+  
 }
 

--- a/lib/data/categoria_repository.dart
+++ b/lib/data/categoria_repository.dart
@@ -1,0 +1,83 @@
+import 'package:dcristaldo/domain/categoria.dart';
+import 'package:dio/dio.dart';
+import 'package:dcristaldo/constants.dart';
+import 'package:dcristaldo/exceptions/api_exception.dart';
+
+class CategoriaRepository {
+  final Dio _dio = Dio();
+  final String path=CategoryConstants.categoriaEndpoint;
+  // Obtener todas las categorías
+   Future<List<Categoria>> obtenerCategorias() async {
+    try {
+      final response = await _dio.get(path);
+
+      if (response.statusCode == 200) {
+        final List<dynamic> categoriasJson = response.data;
+        return categoriasJson.map((json) => Categoria.fromJson(json)).toList();
+      } else {
+        throw ApiException(
+          'Error al obtener las categorías',
+          statusCode: response.statusCode,
+        );
+      }
+    } on DioException catch (e) {
+      throw ApiException(
+        'Error al conectar con la API de categorías: $e',
+        statusCode: e.response?.statusCode,
+      );
+    } catch (e) {
+      throw ApiException('Error desconocido: $e');
+    }
+  }
+
+  // Crear una nueva categoría
+  Future<void> crearCategoria(Categoria categoria) async {
+    try {
+      final response = await _dio.post(
+        path,
+        data: categoria.toJson(),
+      );
+      if (response.statusCode != 201) {
+        throw ApiException(
+          'Error al crear la categoría',
+          statusCode: response.statusCode,
+        );
+      }
+    } catch (e) {
+      throw ApiException('Error al conectar con la API de categorías: $e');
+    }
+  }
+
+  // Actualizar una categoría existente
+  Future<void> actualizarCategoria(String id, Categoria categoria) async {
+    try {
+      final response = await _dio.put(
+        '$path/$id',
+        data: categoria.toJson(),
+      );
+      if (response.statusCode != 200) {
+        throw ApiException(
+          'Error al editar la categoría',
+          statusCode: response.statusCode,
+        );
+      }
+    } catch (e) {
+      throw ApiException('Error al conectar con la API de categorías: $e');
+    }
+  }
+
+  // Eliminar una categoría
+  Future<void> eliminarCategoria(String id) async {
+    try {
+      final response = await _dio.delete('$path/$id');
+      if (response.statusCode != 200 && response.statusCode != 204) {
+        throw ApiException(
+          'Error al eliminar la categoría',
+          statusCode: response.statusCode,
+        );
+      }
+    } catch (e) {
+      throw ApiException('Error al conectar con la API de categorías: $e');
+    }
+  }
+}

--- a/lib/data/categoria_repository.dart
+++ b/lib/data/categoria_repository.dart
@@ -1,83 +1,63 @@
+import 'package:dcristaldo/api/services/categoria_service.dart';
 import 'package:dcristaldo/domain/categoria.dart';
-import 'package:dio/dio.dart';
-import 'package:dcristaldo/constants.dart';
 import 'package:dcristaldo/exceptions/api_exception.dart';
-
 class CategoriaRepository {
-  final Dio _dio = Dio();
-  final String path=CategoryConstants.categoriaEndpoint;
+  final CategoriaService _service= CategoriaService();
+  
   // Obtener todas las categorías
-   Future<List<Categoria>> obtenerCategorias() async {
+  Future<List<Categoria>> obtenerCategorias() async {
     try {
-      final response = await _dio.get(path);
-
-      if (response.statusCode == 200) {
-        final List<dynamic> categoriasJson = response.data;
-        return categoriasJson.map((json) => Categoria.fromJson(json)).toList();
-      } else {
-        throw ApiException(
-          'Error al obtener las categorías',
-          statusCode: response.statusCode,
-        );
-      }
-    } on DioException catch (e) {
-      throw ApiException(
-        'Error al conectar con la API de categorías: $e',
-        statusCode: e.response?.statusCode,
-      );
+      return await _service.obtenerCategorias();
     } catch (e) {
-      throw ApiException('Error desconocido: $e');
+      if (e is ApiException) {
+        // Propaga el mensaje contextual de ApiException
+        rethrow;
+      } else {
+        throw Exception('Error desconocido: $e');
+      }
     }
   }
 
   // Crear una nueva categoría
   Future<void> crearCategoria(Categoria categoria) async {
     try {
-      final response = await _dio.post(
-        path,
-        data: categoria.toJson(),
-      );
-      if (response.statusCode != 201) {
-        throw ApiException(
-          'Error al crear la categoría',
-          statusCode: response.statusCode,
-        );
-      }
+      await _service.crearCategoria(categoria);
     } catch (e) {
-      throw ApiException('Error al conectar con la API de categorías: $e');
+      if (e is ApiException) {
+        // Propaga el mensaje contextual de ApiException
+        throw Exception('Error en el servicio de categorías: ${e.message}');
+      } else {
+        throw Exception('Error desconocido: $e');
+      }
     }
   }
 
   // Actualizar una categoría existente
   Future<void> actualizarCategoria(String id, Categoria categoria) async {
     try {
-      final response = await _dio.put(
-        '$path/$id',
-        data: categoria.toJson(),
-      );
-      if (response.statusCode != 200) {
-        throw ApiException(
-          'Error al editar la categoría',
-          statusCode: response.statusCode,
-        );
-      }
+      await _service.actualizarCategoria(id, categoria);
     } catch (e) {
-      throw ApiException('Error al conectar con la API de categorías: $e');
+      if (e is ApiException) {
+        // Propaga el mensaje contextual de ApiException
+        throw Exception('Error en el servicio de categorías: ${e.message}');
+      } else {
+        throw Exception('Error desconocido: $e');
+      }
     }
   }
+
 
   // Eliminar una categoría
   Future<void> eliminarCategoria(String id) async {
     try {
-      final response = await _dio.delete('$path/$id');
-      if (response.statusCode != 200 && response.statusCode != 204) {
-        throw ApiException(
-          'Error al eliminar la categoría',
-          statusCode: response.statusCode,
-        );
-      }
+      await _service.eliminarCategoria(id);
     } catch (e) {
-      throw ApiException('Error al conectar con la API de categorías: $e');
+      if (e is ApiException) {
+        // Propaga el mensaje contextual de ApiException
+        rethrow;
+      } else {
+        throw Exception('Error desconocido: $e');
+      }
     }
   }
 }

--- a/lib/data/noticia_repository.dart
+++ b/lib/data/noticia_repository.dart
@@ -1,16 +1,16 @@
 import 'dart:async';
 import 'package:dcristaldo/domain/noticia.dart';
 import 'package:dio/dio.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:dcristaldo/constants.dart';
 
 class NoticiaRepository {
   final Dio _dio = Dio();
-  final String _baseUrl = dotenv.env['API_URL'] ?? '';
+  final String path=NewsConstants.noticiasEndpoint;
   /// Crear una nueva noticia
   Future<Noticia> crearNoticia(Noticia noticia) async {
     try {
       final response = await _dio.post(
-        _baseUrl,
+        path,
         data: {
           'titulo': noticia.titulo,
           'descripcion': noticia.descripcion,
@@ -32,7 +32,7 @@ class NoticiaRepository {
   /// Leer todas las noticias
   Future<List<Noticia>> obtenerNoticias() async {
     try {
-      final response = await _dio.get(_baseUrl);
+      final response = await _dio.get(path);
 
       if (response.statusCode == 200) {
         final List<dynamic> data = response.data ?? [];
@@ -48,7 +48,7 @@ class NoticiaRepository {
   /// Leer una noticia por ID
   Future<Noticia> obtenerNoticiaPorId(String id) async {
     try {
-      final response = await _dio.get('$_baseUrl/$id');
+      final response = await _dio.get('$path/$id');
 
       if (response.statusCode == 200) {
         return Noticia.fromJson(response.data);
@@ -64,7 +64,7 @@ class NoticiaRepository {
   Future<void> actualizarNoticia(String id, Noticia noticia) async {
     try {
       final response = await _dio.put(
-        '$_baseUrl/$id',
+        '$path/$id',
         data: {
           'titulo': noticia.titulo,
           'descripcion': noticia.descripcion,
@@ -85,7 +85,7 @@ class NoticiaRepository {
   /// Eliminar una noticia
   Future<void> eliminarNoticia(String id) async {
     try {
-      final response = await _dio.delete('$_baseUrl/$id');
+      final response = await _dio.delete('$path/$id');
 
       if (response.statusCode != 200 && response.statusCode != 204) {
         throw Exception('Error al eliminar la noticia: ${response.statusMessage}');

--- a/lib/data/noticia_repository.dart
+++ b/lib/data/noticia_repository.dart
@@ -1,141 +1,90 @@
-import 'dart:async';
+import 'package:dcristaldo/api/services/noticia_service.dart';
 import 'package:dcristaldo/domain/noticia.dart';
-import 'package:dio/dio.dart';
-import 'package:dcristaldo/constants.dart';
 
 class NoticiaRepository {
-  final Dio _dio = Dio(
-          BaseOptions(
-            connectTimeout: const Duration(seconds: CategoryConstants.timeoutSeconds),
-            receiveTimeout:const  Duration(seconds: CategoryConstants.timeoutSeconds),
-          ),
-        );
-  final String path=NewsConstants.noticiasEndpoint;
+  final NoticiaService _service = NoticiaService();
+
+  /// Obtener todas las noticias sin paginación
+  Future<List<Noticia>> obtenerNoticias() async {
+    // Obtener todas las noticias desde el repositorio
+    final noticias = await _service.obtenerNoticias();
+
+    // Validar que las noticias tengan datos válidos
+    for (final noticia in noticias) {
+      validarNoticia(noticia);
+    }
+
+    return noticias;
+  }
+
   /// Crear una nueva noticia
   Future<Noticia> crearNoticia(Noticia noticia) async {
-    try {
-      final response = await _dio.post(
-        path,
-        data: {
-          'titulo': noticia.titulo,
-          'descripcion': noticia.descripcion,
-          'fuente': noticia.fuente,
-          'publicadaEl': noticia.publicadaEl.toIso8601String(),
-          'urlImage': noticia.imagenUrl,
-          'categoriaId': noticia.categoriaId,
-        },
-      );
-      if (response.statusCode != 201) {
-        throw Exception('Error al crear la noticia: ${response.statusMessage}');
-      }else{
-        return Noticia.fromJson(response.data);
-      }
-    } catch (e) {
+    try{
+      // Validar que los datos de la noticia sean válidos
+      validarNoticia(noticia);
+      // Enviar la noticia al repositorio
+      return await _service.crearNoticia(noticia);
+    }catch(e){
       throw Exception('Error al crear la noticia: $e');
     }
-  }
-
-  /// Leer todas las noticias
-  Future<List<Noticia>> obtenerNoticias() async {
-    try {
-      final response = await _dio.get(path);
-
-      if (response.statusCode == 200) {
-        final List<dynamic> data = response.data ?? [];
-        return data.map((json) => Noticia.fromJson(json)).toList();
-      } else {
-        throw Exception('Error al obtener las noticias: ${response.statusMessage}');
-      }
-    } catch (e) {
-      throw Exception('Error al obtener las noticias: $e');
-    }
-  }
-
-  /// Leer una noticia por ID
-  Future<Noticia> obtenerNoticiaPorId(String id) async {
-    try {
-      final response = await _dio.get('$path/$id');
-
-      if (response.statusCode == 200) {
-        return Noticia.fromJson(response.data);
-      } else {
-        throw Exception('Error al obtener la noticia: ${response.statusMessage}');
-      }
-    } catch (e) {
-      throw Exception('Error al obtener la noticia: $e');
-    }
+    
   }
 
   /// Actualizar una noticia
   Future<void> actualizarNoticia(String id, Noticia noticia) async {
-    try {
-      final response = await _dio.put(
-        '$path/$id',
-        data: {
-          'titulo': noticia.titulo,
-          'descripcion': noticia.descripcion,
-          'fuente': noticia.fuente,
-          'publicadaEl': noticia.publicadaEl.toIso8601String(),
-          'urlImage': noticia.imagenUrl,
-          'categoriaId': noticia.categoriaId,
-        },
-      );
-
-      if (response.statusCode != 200) {
-        throw Exception('Error al actualizar la noticia: ${response.statusMessage}');
-      }
-    } catch (e) {
-      throw Exception('Error al actualizar la noticia: $e');
-    }
+    validarNoticia(noticia);
+    await _service.actualizarNoticia(id, noticia);
   }
 
   /// Eliminar una noticia
   Future<void> eliminarNoticia(String id) async {
-    try {
-      final response = await _dio.delete('$path/$id');
+    // Eliminar la noticia desde el repositorio
+    await _service.eliminarNoticia(id);
+  }
 
-      if (response.statusCode != 200 && response.statusCode != 204) {
-        throw Exception('Error al eliminar la noticia: ${response.statusMessage}');
-      }
-    } catch (e) {
-      throw Exception('Error al eliminar la noticia: $e');
+  /// Validar los datos de una noticia
+  void validarNoticia(Noticia noticia) {
+    if (noticia.publicadaEl.isAfter(DateTime.now())) {
+      throw ArgumentError('La fecha de publicación no puede estar en el futuro.');
+    }
+    if (noticia.titulo.trim().isEmpty) {
+      throw ArgumentError('El título de la noticia no puede estar vacío.');
+    }
+    if (noticia.descripcion.trim().isEmpty) {
+      throw ArgumentError('La descripción de la noticia no puede estar vacía.');
+    }
+    if (noticia.fuente.trim().isEmpty) {
+      throw ArgumentError('La fuente de la noticia no puede estar vacía.');
+    }
+    if (noticia.imagenUrl.trim().isEmpty) {
+      throw ArgumentError('La URL de la imagen no puede estar vacía.');
     }
   }
-  
-  /*Future<List<Noticia>> obtenerNoticiasDesdeApi({
+
+  /// Obtener noticias paginadas
+  /*Future<List<Noticia>> obtenerNoticiasPaginadas({
     required int numeroPagina,
-    required int tamanoPagina,
+    required int tamanoPaginaConst,
   }) async {
-    try {
-      // Realizar la solicitud HTTP a la API
-      final response = await _dio.get(
-        NewsConstants.url,
-      );
+    // Validar que numeroPagina sea mayor o igual a 1 y tamañoPagina mayor a 0
+    if (numeroPagina < 1) {
+      throw ArgumentError('El número de página debe ser mayor o igual a 1.');
+    }
+    if (tamanoPaginaConst <= 0) {
+      throw ArgumentError('El tamaño de página debe ser mayor a 0.');
+    }
 
-      if (response.statusCode == 200) {
-        final List<dynamic> data = response.data ?? [];
-        return data.map((json) => Noticia.fromJson(json)).toList();
-      } else {
-        throw Exception('Error al obtener las noticias: ${response.statusCode}');
-      }
-    } catch (e) {
-      throw Exception('Error al realizar la solicitud: $e');
+    // Obtener las noticias paginadas desde el repositorio
+    final noticias = await _service.obtenerNoticias(
+      numeroPagina: numeroPagina,
+      tamanoPagina: tamanoPaginaConst,
+    );
+
+    // Validar que las noticias tengan datos válidos
+    for (final noticia in noticias) {
+      validarNoticia(noticia);
     }
-  }
-  Future<void> crearNoticia(Noticia noticia) async {
-    try {
-      await _dio.post(
-        NewsConstants.url, // Cambia esta URL por la de tu API
-        data: {
-          'titulo': noticia.titulo,
-          'descripcion': noticia.descripcion,
-          'fuente': noticia.fuente,
-          'publicadaEl': noticia.publicadaEl.toIso8601String(),
-          'urlImage': noticia.imagenUrl,
-        },
-      );
-    } catch (e) {
-      throw Exception('Error al crear la noticia: $e');
-    }
+
+    return noticias;
   }*/
 }

--- a/lib/data/noticia_repository.dart
+++ b/lib/data/noticia_repository.dart
@@ -4,7 +4,12 @@ import 'package:dio/dio.dart';
 import 'package:dcristaldo/constants.dart';
 
 class NoticiaRepository {
-  final Dio _dio = Dio();
+  final Dio _dio = Dio(
+          BaseOptions(
+            connectTimeout: const Duration(seconds: CategoryConstants.timeoutSeconds),
+            receiveTimeout:const  Duration(seconds: CategoryConstants.timeoutSeconds),
+          ),
+        );
   final String path=NewsConstants.noticiasEndpoint;
   /// Crear una nueva noticia
   Future<Noticia> crearNoticia(Noticia noticia) async {
@@ -17,6 +22,7 @@ class NoticiaRepository {
           'fuente': noticia.fuente,
           'publicadaEl': noticia.publicadaEl.toIso8601String(),
           'urlImage': noticia.imagenUrl,
+          'categoriaId': noticia.categoriaId,
         },
       );
       if (response.statusCode != 201) {
@@ -71,6 +77,7 @@ class NoticiaRepository {
           'fuente': noticia.fuente,
           'publicadaEl': noticia.publicadaEl.toIso8601String(),
           'urlImage': noticia.imagenUrl,
+          'categoriaId': noticia.categoriaId,
         },
       );
 

--- a/lib/domain/categoria.dart
+++ b/lib/domain/categoria.dart
@@ -1,0 +1,35 @@
+// category.dart
+class Categoria {
+  final String? id; // ID asignado por la API (opcional, para operaciones CRUD)
+  final String nombre; // Nombre de la categoría (por ejemplo, "Inteligencia Artificial")
+  final String descripcion; // Descripción breve (por ejemplo, "Noticias sobre IA")
+  String imagenUrl="https://picsum.photos/seed/picsum/200/300"; // URL de la imagen representativa de la categoría
+
+  Categoria({
+    this.id, // Puede ser null al crear una categoría, se asigna al guardarla
+    required this.nombre,
+    required this.descripcion,
+    required imagenUrl,
+  }){
+    //this.imagenUrl = imagenUrl;
+  }
+
+  // Método para convertir un JSON de la API a un objeto Category
+  factory Categoria.fromJson(Map<String, dynamic> json) {
+    return Categoria(
+      id: json['_id'] as String?, // El ID lo asigna CrudCrud
+      nombre: json['nombre'] as String,
+      descripcion: json['descripcion'] as String,
+      imagenUrl: json['imagenUrl'] as String,
+    );
+  }
+
+  // Método para convertir el objeto Categoria a JSON para enviar a la API
+  Map<String, dynamic> toJson() {
+    return {
+      'nombre': nombre,
+      'descripcion': descripcion,
+      'imagenUrl': imagenUrl,
+    };
+  }
+}

--- a/lib/domain/noticia.dart
+++ b/lib/domain/noticia.dart
@@ -1,3 +1,4 @@
+import 'package:dcristaldo/constants.dart';
 class Noticia {
   String id;
   final String titulo;
@@ -5,7 +6,7 @@ class Noticia {
   final String fuente;
   final DateTime publicadaEl;
   final String imagenUrl;
-  final String? categoriaId;
+  String categoriaId=NewsConstants.defaultcategoriaId;
 
   Noticia({
     required this.titulo,

--- a/lib/domain/noticia.dart
+++ b/lib/domain/noticia.dart
@@ -5,6 +5,7 @@ class Noticia {
   final String fuente;
   final DateTime publicadaEl;
   final String imagenUrl;
+  final String? categoriaId;
 
   Noticia({
     required this.titulo,
@@ -13,6 +14,7 @@ class Noticia {
     required this.publicadaEl,
     required this.imagenUrl,
     required this.id,
+    required this.categoriaId,
   });
 
   factory Noticia.fromJson(Map<String, dynamic> json) {
@@ -23,7 +25,7 @@ class Noticia {
       fuente: json['fuente']?? 'Fuente desconocida',
       publicadaEl: DateTime.parse(json['publicadaEl'] ?? DateTime.now().toIso8601String()),
       imagenUrl: json['urlImage'] ?? 'https://demofree.sirv.com/nope-not-here.jpg?w=150', // Si no hay imagen, se asigna una cadena vacía
-    );
+      categoriaId: json['categoriaId'],);
   }
   Map<String, dynamic> toJson() {
     return {
@@ -32,6 +34,7 @@ class Noticia {
       'fuente': fuente,
       'publicadaEl': publicadaEl.toIso8601String(),
       'urlImage': imagenUrl,
+      'categoriaId': categoriaId,
     };
   }
 

--- a/lib/exceptions/api_exception.dart
+++ b/lib/exceptions/api_exception.dart
@@ -1,0 +1,10 @@
+
+class ApiException implements Exception {
+  final String message;
+  final int? statusCode;
+  ApiException(this.message, {this.statusCode});
+  @override
+  String toString() {
+    return 'ApiException: $message (Código: $statusCode)';
+  }
+}

--- a/lib/helpers/error_helper.dart
+++ b/lib/helpers/error_helper.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+class ErrorHelper {
+  /// Devuelve un mensaje y un color basado en el código HTTP
+  static Map<String, dynamic> getErrorMessageAndColor(int? statusCode) {
+    String message;
+    Color color;
+    switch (statusCode) {
+      case 400:
+        message = 'Solicitud incorrecta. Verifica los datos enviados.';
+        color = Colors.orange;
+        break;
+      case 401:
+        message = 'No autorizado. Verifica tus credenciales.';
+        color = Colors.red;
+        break;
+      case 403:
+        message = 'Prohibido. No tienes permisos para acceder.';
+        color = Colors.redAccent;
+        break;
+      case 404:
+        message = 'Recurso no encontrado. Verifica la URL.';
+        color = Colors.blueGrey;
+        break;
+      case 500:
+        message = 'Error interno del servidor. Intenta más tarde.';
+        color = Colors.red;
+        break;
+      default:
+        message = 'Ocurrió un error desconocido.';
+        color = Colors.grey;
+        break;
+    }
+    return {'message': message, 'color': color};
+  }
+}

--- a/lib/helpers/error_helper.dart
+++ b/lib/helpers/error_helper.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:dcristaldo/constants.dart';
 
 class ErrorHelper {
   /// Devuelve un mensaje y un color basado en el código HTTP
@@ -7,23 +8,23 @@ class ErrorHelper {
     Color color;
     switch (statusCode) {
       case 400:
-        message = 'Solicitud incorrecta. Verifica los datos enviados.';
-        color = Colors.orange;
-        break;
-      case 401:
-        message = 'No autorizado. Verifica tus credenciales.';
+        message = ErrorConstants.errorMessage;
         color = Colors.red;
         break;
+      case 401:
+        message = ErrorConstants.errorUnauthorized;
+        color = Colors.orange;
+        break;
       case 403:
-        message = 'Prohibido. No tienes permisos para acceder.';
+        message = ErrorConstants.errorForbidden;
         color = Colors.redAccent;
         break;
       case 404:
-        message = 'Recurso no encontrado. Verifica la URL.';
-        color = Colors.blueGrey;
+        message = ErrorConstants.errorNotFound;
+        color = Colors.grey;
         break;
       case 500:
-        message = 'Error interno del servidor. Intenta más tarde.';
+        message = ErrorConstants.errorServer;
         color = Colors.red;
         break;
       default:

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:dcristaldo/views/task_screen.dart';
 import 'package:dcristaldo/views/quote_screen.dart';
 import 'package:dcristaldo/views/noticia_screen.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:dcristaldo/views/categoria_screen.dart';
 //import 'package:dcristaldo/views/mi_screen.dart';
 //import 'package:dcristaldo/views/color_change_screen.dart';
 Future<void> main() async {
@@ -42,6 +43,7 @@ class MyApp extends StatelessWidget {
         '/game': (context) => const GameScreen(),
         '/quote': (context) => const QuoteScreen(),
         '/noticias': (context) => const NoticiaScreen(),
+        '/categorias': (context) => const CategoriaScreen(),
       },
     );
   }

--- a/lib/views/base_screen.dart
+++ b/lib/views/base_screen.dart
@@ -93,6 +93,13 @@ class BaseScreen extends StatelessWidget {
               },
             ),
             ListTile(
+              leading: const Icon(Icons.category),
+              title: const Text('Categorias'),
+              onTap: () {
+                Navigator.pushReplacementNamed(context, '/categorias');
+              },
+            ),
+            ListTile(
               leading: const Icon(Icons.logout),
               title: const Text('Cerrar Sesión'),
               onTap: () {

--- a/lib/views/categoria_screen.dart
+++ b/lib/views/categoria_screen.dart
@@ -1,0 +1,261 @@
+import 'package:flutter/material.dart';
+import 'package:dcristaldo/api/services/categoria_service.dart';
+import 'package:dcristaldo/domain/categoria.dart';
+import 'package:dcristaldo/components/custom_form_modal.dart';
+import 'package:dcristaldo/views/base_screen.dart';
+import 'package:dcristaldo/exceptions/api_exception.dart';
+import 'package:dcristaldo/helpers/error_helper.dart';
+class CategoriaScreen extends StatefulWidget {
+  const CategoriaScreen({super.key});
+
+  @override
+  CategoriaScreenState createState() => CategoriaScreenState();
+}
+
+class CategoriaScreenState extends State<CategoriaScreen> {
+  late final CategoriaService _categoriaService=CategoriaService();
+  List<Categoria> _categorias = [];
+  bool _isLoading = false;
+  bool _hasError = false;
+   
+
+  @override
+  void initState() {
+    super.initState();
+    
+    _loadCategorias();
+  }
+
+  Future<void> _loadCategorias() async {
+    setState(() {
+      _isLoading = true;
+      _hasError = false;
+    });
+
+    try {
+      final categorias = await _categoriaService.obtenerCategorias();
+      setState(() {
+        _categorias = categorias;
+        _isLoading = false;
+      });
+    } catch (e) {
+      setState(() {
+        _isLoading = false;
+        _hasError = true;
+      });
+      String errorMessage='Error al cargar las categorías';
+      Color errorColor=Colors.grey; 
+      if (e is ApiException) {
+        final errorData = ErrorHelper.getErrorMessageAndColor(e.statusCode);
+        errorMessage = errorData['message'];
+        errorColor = errorData['color'];
+      }
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(errorMessage), backgroundColor: errorColor),
+        );
+      }
+    }
+    
+  }
+  Future<void> _deleteCategoria(String id) async {
+    setState(() {
+      _isLoading = true;
+    });
+
+    try {
+      await _categoriaService.eliminarCategoria(id);
+      _loadCategorias();
+    } catch (e) {
+      setState(() {
+        _isLoading = false;
+        _hasError = true;
+      });
+      String errorMessage='Error al eliminar la categoría';
+      Color errorColor=Colors.grey; 
+      if (e is ApiException) {
+        final errorData = ErrorHelper.getErrorMessageAndColor(e.statusCode);
+        errorMessage = errorData['message'];
+        errorColor = errorData['color'];
+      }
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(errorMessage), backgroundColor: errorColor),
+        );
+      }
+    } finally {
+      setState(() {
+        _isLoading = false;
+      });
+    }
+  }
+  void _showDeleteConfirmationDialog(String id) {
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Eliminar Categoría'),
+          content: const Text('¿Estás seguro de que deseas eliminar esta categoría?'),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+              child: const Text('Cancelar'),
+            ),
+            TextButton(
+              onPressed: () {
+                _deleteCategoria(id);
+                Navigator.of(context).pop();
+              },
+              style: const ButtonStyle(
+                backgroundColor: WidgetStatePropertyAll(Colors.red),
+              ),
+              child: const Text('Eliminar'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+  void _showCategoriaModal({Categoria? categoria}) {
+    final nombreController = TextEditingController(text: categoria?.nombre ?? '');
+    final descripcionController =
+        TextEditingController(text: categoria?.descripcion ?? '');
+    final imagenUrlController =
+        TextEditingController(text: categoria?.imagenUrl ?? '');
+
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) {
+        return CustomFormModal(
+          title: categoria == null ? 'Agregar Categoría' : 'Actualizar Categoría',
+          controllers: {
+            'nombre': nombreController,
+            'descripcion': descripcionController,
+            'imagenUrl': imagenUrlController,
+          },
+          fieldLabels: {
+            'nombre': 'Nombre',
+            'descripcion': 'Descripción',
+            'imagenUrl': 'URL de la Imagen',
+          },
+          onSubmit: () async {
+            final nombre = nombreController.text.trim();
+            final descripcion = descripcionController.text.trim();
+            final imagenUrl = imagenUrlController.text.trim();
+
+            if (nombre.isEmpty || descripcion.isEmpty) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  content: Text('Por favor, completa todos los campos obligatorios'),
+                  backgroundColor: Colors.red,
+                ),
+              );
+              return;
+            }
+
+            setState(() {
+              _isLoading = true;
+            });
+
+            try {
+              if (categoria == null) {
+                // Agregar nueva categoría
+                await _categoriaService.crearCategoria(
+                  Categoria(
+                    id: '',
+                    nombre: nombre,
+                    descripcion: descripcion,
+                    imagenUrl: imagenUrl,
+                  ),
+                );
+              } else {
+                // Actualizar categoría existente
+                await _categoriaService.actualizarCategoria(
+                  categoria.id!,
+                  Categoria(
+                    id: categoria.id!,
+                    nombre: nombre,
+                    descripcion: descripcion,
+                    imagenUrl: imagenUrl,
+                  ),
+                );
+              }
+              // ignore: use_build_context_synchronously
+              Navigator.pop(context);
+              _loadCategorias();
+            } catch (e) {
+              // ignore: use_build_context_synchronously
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text('Error: ${e.toString()}'),
+                  backgroundColor: Colors.red,
+                ),
+              );
+            } finally {
+              setState(() {
+                _isLoading = false;
+              });
+            }
+          },
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseScreen(
+      appBar: AppBar(title: const Text('Categorías')),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : _hasError
+              ? const Center(child: Text('Error al cargar las categorías'))
+              : ListView.builder(
+                  itemCount: _categorias.length,
+                  itemBuilder: (context, index) {
+                    final categoria = _categorias[index];
+                    return ListTile(
+                      leading: 
+                          Image.network(
+                              categoria.imagenUrl,
+                              width: 50,
+                              height: 50,
+                              fit: BoxFit.cover,
+                            ),
+                      title: Text(categoria.nombre),
+                      subtitle: Text(categoria.descripcion),
+                      trailing: ConstrainedBox(
+                        constraints: const BoxConstraints(maxWidth: 100), // Limitar el ancho máximo
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            IconButton(
+                              icon: const Icon(Icons.edit, color: Colors.blue),
+                              onPressed: () {
+                                _showCategoriaModal(categoria: categoria); // Abrir modal para editar
+                              },
+                            ),
+                            IconButton(
+                              icon: const Icon(Icons.delete, color: Colors.red),
+                              onPressed: () {
+                                _showDeleteConfirmationDialog(categoria.id!); // Confirmar eliminación
+                              },
+                            ),
+                          ],
+                        ),
+                      ),
+                    );
+                  },
+                ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          _showCategoriaModal();
+        },
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/lib/views/categoria_screen.dart
+++ b/lib/views/categoria_screen.dart
@@ -110,6 +110,7 @@ class CategoriaScreenState extends State<CategoriaScreen> {
               },
               style: const ButtonStyle(
                 backgroundColor: WidgetStatePropertyAll(Colors.red),
+                foregroundColor: WidgetStatePropertyAll(Colors.white),
               ),
               child: const Text('Eliminar'),
             ),

--- a/lib/views/categoria_screen.dart
+++ b/lib/views/categoria_screen.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:dcristaldo/api/services/categoria_service.dart';
+import 'package:dcristaldo/data/categoria_repository.dart';
 import 'package:dcristaldo/domain/categoria.dart';
 import 'package:dcristaldo/components/custom_form_modal.dart';
 import 'package:dcristaldo/views/base_screen.dart';
 import 'package:dcristaldo/exceptions/api_exception.dart';
 import 'package:dcristaldo/helpers/error_helper.dart';
+
 class CategoriaScreen extends StatefulWidget {
   const CategoriaScreen({super.key});
 
@@ -13,7 +14,7 @@ class CategoriaScreen extends StatefulWidget {
 }
 
 class CategoriaScreenState extends State<CategoriaScreen> {
-  late final CategoriaService _categoriaService=CategoriaService();
+  late final CategoriaRepository _categoriaRepository=CategoriaRepository();
   List<Categoria> _categorias = [];
   bool _isLoading = false;
   bool _hasError = false;
@@ -33,7 +34,7 @@ class CategoriaScreenState extends State<CategoriaScreen> {
     });
 
     try {
-      final categorias = await _categoriaService.obtenerCategorias();
+      final categorias = await _categoriaRepository.obtenerCategorias();
       setState(() {
         _categorias = categorias;
         _isLoading = false;
@@ -64,7 +65,7 @@ class CategoriaScreenState extends State<CategoriaScreen> {
     });
 
     try {
-      await _categoriaService.eliminarCategoria(id);
+      await _categoriaRepository.eliminarCategoria(id);
       _loadCategorias();
     } catch (e) {
       setState(() {
@@ -164,7 +165,7 @@ class CategoriaScreenState extends State<CategoriaScreen> {
             try {
               if (categoria == null) {
                 // Agregar nueva categoría
-                await _categoriaService.crearCategoria(
+                await _categoriaRepository.crearCategoria(
                   Categoria(
                     id: '',
                     nombre: nombre,
@@ -174,7 +175,7 @@ class CategoriaScreenState extends State<CategoriaScreen> {
                 );
               } else {
                 // Actualizar categoría existente
-                await _categoriaService.actualizarCategoria(
+                await _categoriaRepository.actualizarCategoria(
                   categoria.id!,
                   Categoria(
                     id: categoria.id!,

--- a/lib/views/noticia_screen.dart
+++ b/lib/views/noticia_screen.dart
@@ -135,6 +135,7 @@ class NoticiaScreenState extends State<NoticiaScreen> {
                         imagenUrl: imagenUrl.isNotEmpty
                             ? imagenUrl
                             : 'https://demofree.sirv.com/nope-not-here.jpg?w=150',
+                        categoriaId: NewsConstants.defaultcategoriaId,
                       );
                       try {
                         final noticiaCreada = await _noticiaService.crearNoticia(nuevaNoticia);
@@ -254,6 +255,7 @@ class NoticiaScreenState extends State<NoticiaScreen> {
                         fuente: fuente,
                         publicadaEl: noticia.publicadaEl,
                         imagenUrl: imagenUrl,
+                        categoriaId: NewsConstants.defaultcategoriaId,
                       );
                       try {
                         await _noticiaService.actualizarNoticia(noticia.id, noticiaActualizada);

--- a/lib/views/noticia_screen.dart
+++ b/lib/views/noticia_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:dcristaldo/api/services/noticia_service.dart';
+import 'package:dcristaldo/data/noticia_repository.dart';
 import 'package:dcristaldo/components/noticia_card.dart';
 import 'package:dcristaldo/views/base_screen.dart';
 import 'package:dcristaldo/constants.dart';
@@ -13,7 +13,7 @@ class NoticiaScreen extends StatefulWidget {
 }
 
 class NoticiaScreenState extends State<NoticiaScreen> {
-  final NoticiaService _noticiaService = NoticiaService();
+  final NoticiaRepository _noticiaRepository = NoticiaRepository();
   final List<Noticia> _noticias = [];
   bool _isLoading = false;
   bool hasError = false;
@@ -33,7 +33,7 @@ class NoticiaScreenState extends State<NoticiaScreen> {
     });
 
     try {
-      final nuevasNoticias = await _noticiaService.obtenerNoticias();
+      final nuevasNoticias = await _noticiaRepository.obtenerNoticias();
       if (!mounted) return;
       setState(() {
         _noticias.clear();
@@ -138,7 +138,7 @@ class NoticiaScreenState extends State<NoticiaScreen> {
                         categoriaId: NewsConstants.defaultcategoriaId,
                       );
                       try {
-                        final noticiaCreada = await _noticiaService.crearNoticia(nuevaNoticia);
+                        final noticiaCreada = await _noticiaRepository.crearNoticia(nuevaNoticia);
                         setState(() {
                           _noticias.insert(0, noticiaCreada);
                           _ultimaActualizacion = DateTime.now();
@@ -258,7 +258,7 @@ class NoticiaScreenState extends State<NoticiaScreen> {
                         categoriaId: NewsConstants.defaultcategoriaId,
                       );
                       try {
-                        await _noticiaService.actualizarNoticia(noticia.id, noticiaActualizada);
+                        await _noticiaRepository.actualizarNoticia(noticia.id, noticiaActualizada);
                         setState(() {
                           final index = _noticias.indexWhere((n) => n.id == noticia.id);
                           if (index != -1) {
@@ -376,7 +376,7 @@ class NoticiaScreenState extends State<NoticiaScreen> {
                         });
 
                         try {
-                          await _noticiaService.eliminarNoticia(noticia.id);
+                          await _noticiaRepository.eliminarNoticia(noticia.id);
                           if (context.mounted) {
                             ScaffoldMessenger.of(context).showSnackBar(
                               SnackBar(content: Text('Noticia eliminada: ${noticia.titulo}')),


### PR DESCRIPTION
Externaliza la configuración de la API (base URL y rutas relativas).
Maneja errores HTTP (200, 400, 401, 404, 500) en las consultas de red.
Implementa operaciones CRUD completas para las noticias y una nueva entidad relacionada: Categorías.
Analiza con dart analyze
